### PR TITLE
fix webkit bug

### DIFF
--- a/requirements/frontend/src/components/notification/Notifications.scss
+++ b/requirements/frontend/src/components/notification/Notifications.scss
@@ -35,6 +35,8 @@
             position: absolute;
             top: 50%;
             left: 50%;
+            width: 30px;
+            height: 30px;
             transform: translate(-50%, -50%);
             color: #fff;
         }


### PR DESCRIPTION
fix d'un bug visuel sur le bouton d'ouverture des notifications avec le webkit (iOS, safari)

avant
<img width="97" alt="Capture d’écran 2022-01-23 à 18 06 03" src="https://user-images.githubusercontent.com/54767855/150689576-c285ef63-6d73-4ce0-9e59-e4736980bb91.png">

apres
<img width="97" alt="Capture d’écran 2022-01-23 à 18 05 28" src="https://user-images.githubusercontent.com/54767855/150689549-d3ce3a86-c90c-4e67-9c57-a79bed31c2c6.png">


