### PR TITLE
Matchmaking backend

### DIFF
--- a/requirements/backend/src/game/game.controller.ts
+++ b/requirements/backend/src/game/game.controller.ts
@@ -1,22 +1,34 @@
-import { Body, Controller, Inject, Post } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, HttpStatus, Inject, Param, Post, Req } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { User } from "src/user/entities/user.entity";
 import { Repository } from "typeorm";
 import { GameService } from "./game.service";
-import { PlayerState } from "./types/PlayerState";
+import { TestUser } from "./types/Matchmaking";
 
-@Controller('game')
+@Controller('matchmaking')
 export class GameController {
 	constructor(
 		@InjectRepository(User) private userRepo: Repository<User>,
 		@Inject(GameService) private gameService: GameService
 	) {}
 
-	@Post('match')
-	createMatch(@Body() body: {
-		winner: PlayerState,
-		loser: PlayerState
-	}) {
-		return this.gameService.saveMatchResult(body.winner, body.loser);;
+	@Post('test')
+	@HttpCode(HttpStatus.OK)
+ 	testNormalStartMatchmaking(@Body() body: TestUser) {
+		return this.gameService.matchmakingAddPlayer(body);
+	}
+
+	// guard
+	@Post('join')
+	@HttpCode(HttpStatus.OK)
+ 	startMatchmaking(@Req() req: { user: User }) {
+		return this.gameService.matchmakingAddPlayer(req.user);
+	}
+
+	// guard
+	@Get('state/:id')
+	getMatchmakingState(@Param('id') id: number) {
+		const res = this.gameService.matchmakingCheckMatch(id);
+		return res ? HttpStatus.OK : HttpStatus.NOT_FOUND;
 	}
 }

--- a/requirements/backend/src/game/game.controller.ts
+++ b/requirements/backend/src/game/game.controller.ts
@@ -8,17 +8,9 @@ import { GameOptions } from "./types/GameOptions";
 @Controller('game')
 export class GameController {
 	constructor(
-		@InjectRepository(User) private userRepo: Repository<User>,
 		@Inject(GameService) private gameService: GameService
 	) {}
 
-	@Post('test')
-	@HttpCode(HttpStatus.OK)
- 	testNormalStartMatchmaking(@Body() body: TestUser) {
-		return this.gameService.matchmakingAddPlayer(body);
-	}
-
-	// guard
 	@Post('join')
 	@UseGuards(GroupGuard)
 	@ApiResponse({
@@ -46,5 +38,17 @@ export class GameController {
 		throw new InternalServerErrorException("We can't match you with another player for now, try again later");
 	}
 
+	@Post('create')
+	@UseGuards(GroupGuard)
+	@ApiResponse({
+		status: 201,
+		description: "Create a private match with the parameters specified in the body"
+	})
+	createPrivateMatch(@Body() body: {
+		ids: [number, number],
+		options: Partial<GameOptions>
+	}) {
+		return this.gameService.createMatch(body.ids, body.options);
 	}
+
 }

--- a/requirements/backend/src/game/game.controller.ts
+++ b/requirements/backend/src/game/game.controller.ts
@@ -1,11 +1,11 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Inject, Param, Post, Req } from "@nestjs/common";
-import { InjectRepository } from "@nestjs/typeorm";
+import { Body, Controller, Get, Inject, InternalServerErrorException, Param, ParseIntPipe, Post, Req, UseGuards } from "@nestjs/common";
+import { ApiResponse } from "@nestjs/swagger";
+import { GroupGuard } from "src/auth/guards/group.guard";
 import { User } from "src/user/entities/user.entity";
-import { Repository } from "typeorm";
 import { GameService } from "./game.service";
-import { TestUser } from "./types/Matchmaking";
+import { GameOptions } from "./types/GameOptions";
 
-@Controller('matchmaking')
+@Controller('game')
 export class GameController {
 	constructor(
 		@InjectRepository(User) private userRepo: Repository<User>,
@@ -20,15 +20,31 @@ export class GameController {
 
 	// guard
 	@Post('join')
-	@HttpCode(HttpStatus.OK)
+	@UseGuards(GroupGuard)
+	@ApiResponse({
+		status: 201,
+		description: "Add the player to the matchmaking queue"
+	})
  	startMatchmaking(@Req() req: { user: User }) {
 		return this.gameService.matchmakingAddPlayer(req.user);
 	}
 
-	// guard
-	@Get('state/:id')
-	getMatchmakingState(@Param('id') id: number) {
-		const res = this.gameService.matchmakingCheckMatch(id);
-		return res ? HttpStatus.OK : HttpStatus.NOT_FOUND;
+	@Get('matchmaking/:id')
+	@UseGuards(GroupGuard)
+	@ApiResponse({
+		status: 200,
+		description: "Returns the match id if any, 0 otherwise"
+	})
+	@ApiResponse({
+		status: 500,
+		description: "Error while trying to create a new match"
+	})
+	getMatchmakingState(@Param('id', ParseIntPipe) id: number) {
+		const matchId: number = this.gameService.matchmakingCheckMatch(id);
+		if (matchId != -1)
+			return matchId;
+		throw new InternalServerErrorException("We can't match you with another player for now, try again later");
+	}
+
 	}
 }

--- a/requirements/backend/src/game/game.controller.ts
+++ b/requirements/backend/src/game/game.controller.ts
@@ -21,7 +21,7 @@ export class GameController {
 		return this.gameService.matchmakingAddPlayer(req.user);
 	}
 
-	@Get('matchmaking/:id')
+	@Get('matchmaking')
 	@UseGuards(GroupGuard)
 	@ApiResponse({
 		status: 200,
@@ -31,8 +31,8 @@ export class GameController {
 		status: 500,
 		description: "Error while trying to create a new match"
 	})
-	getMatchmakingState(@Param('id', ParseIntPipe) id: number) {
-		const matchId: number = this.gameService.matchmakingCheckMatch(id);
+	getMatchmakingState(@Req() req: { user: User }) {
+		const matchId: number = this.gameService.matchmakingCheckMatch(req.user.id);
 		if (matchId != -1)
 			return matchId;
 		throw new InternalServerErrorException("We can't match you with another player for now, try again later");

--- a/requirements/backend/src/game/game.gateway.ts
+++ b/requirements/backend/src/game/game.gateway.ts
@@ -29,6 +29,10 @@ export class GameGateway {
 	/* relie les joueurs à l'id de leur instance */
 	private associatedPlayers : { [userId: number]: number | undefined } = {};
 
+	afterInit(server: Server) {
+		this.gameService.gatewayPtr = this;
+	}
+
 	handleConnection() {}
 
 	handleDisconnect(client: Socket & { request: { user: User } }) {

--- a/requirements/backend/src/game/game.service.ts
+++ b/requirements/backend/src/game/game.service.ts
@@ -4,13 +4,62 @@ import { MatchHistory } from "src/user/entities/match-history.entity";
 import { User } from "src/user/entities/user.entity";
 import { Repository } from "typeorm";
 import { PlayerState } from "./types/PlayerState";
+import { TestUser, MatchmakingList } from "./types/Matchmaking"
 
 @Injectable()
 export class GameService {
-	constructor(
-        @InjectRepository(User) private userRepo: Repository<User>,
-        @InjectRepository(MatchHistory) private matchRepo: Repository<MatchHistory>    
-    ) {}
+
+    private list: MatchmakingList;
+
+    async matchWaitingPlayers() {
+        while (true) {
+            await new Promise(resolve => setTimeout(() => { resolve(true) }, 1000));
+
+            let i = 1;
+            while (i < this.list.waiting.length) {
+    
+                // compute elo gap between the two players
+                const actualDiff = this.list.waiting[i - 1].user.elo - this.list.waiting[i].user.elo;
+                // every 15s the allowed elo gap is bigger by 250 elo
+                const allowedDiff = 250 * (Math.floor((Date.now() - this.list.waiting[i].time) / 15000) + 1);
+    
+                // if the players have a fairly close level
+                if (actualDiff <= allowedDiff) { // it's a match !
+                    this.list.finished.push([this.list.waiting[i - 1].user, this.list.waiting[i].user])
+                    this.list.waiting.splice(i - 1, 2); // remove them from waiting list
+                }
+    
+                i++;
+            }
+        }
+    }
+
+    matchmakingAddPlayer(player: TestUser) {
+
+        let i = 0;
+        while (i < this.list.waiting.length && this.list.waiting[i].user.elo > player.elo) {
+            i++;
+        } // find player position in sorted list (elo desc.)
+
+        // insert player in the waiting list where he belongs
+        this.list.waiting.splice(i, 0, {
+            user: player,
+            time: Date.now()
+        });
+        return this.list;
+    }
+
+    matchmakingCheckMatch(playerId: number) {
+        const match = this.list.finished.find(match => {
+            return (match[0].id === playerId || match[1].id === playerId);
+        });
+
+        if (!match)
+            return null;
+
+        // create a new match instance
+        // return its id
+    }
 
     async saveMatchResult(
         winner: PlayerState,
@@ -79,5 +128,13 @@ export class GameService {
         ]
 
         return updatedElo;
+    }
+
+    constructor(
+        @InjectRepository(User) private userRepo: Repository<User>,
+        @InjectRepository(MatchHistory) private matchRepo: Repository<MatchHistory>    
+    ) {
+        this.list = { waiting: [], finished: [] };
+        this.matchWaitingPlayers(); // launch matching loop
     }
 }

--- a/requirements/backend/src/game/game.service.ts
+++ b/requirements/backend/src/game/game.service.ts
@@ -123,7 +123,7 @@ export class GameService {
         // players[0] is the winner
         players.sort((a: User, b: User) => {
             return a.id === winner.id ? -1 : 1;
-        });body
+        });
 
         // compute new elo
         const updatedElo = this.computeNewEloScore(players[0].elo, players[1].elo);

--- a/requirements/backend/src/game/game.service.ts
+++ b/requirements/backend/src/game/game.service.ts
@@ -27,7 +27,7 @@ export class GameService {
 
     async matchWaitingPlayers() {
         while (true) {
-            await new Promise(resolve => setTimeout(() => { resolve(true) }, 2000));
+            await new Promise(resolve => setTimeout(() => { resolve(true) }, 1000));
 
             let i = 1;
             while (i < this.list.waiting.length) {

--- a/requirements/backend/src/game/game.service.ts
+++ b/requirements/backend/src/game/game.service.ts
@@ -4,20 +4,33 @@ import { MatchHistory } from "src/user/entities/match-history.entity";
 import { User } from "src/user/entities/user.entity";
 import { Repository } from "typeorm";
 import { PlayerState } from "./types/PlayerState";
-import { TestUser, MatchmakingList } from "./types/Matchmaking"
+import { MatchmakingList } from "./types/Matchmaking"
+import { GameGateway } from "./game.gateway";
+import { GameOptions } from "./types/GameOptions";
 
 @Injectable()
 export class GameService {
 
     private list: MatchmakingList;
+    public gatewayPtr: GameGateway | undefined = undefined;
+
+    createMatch(ids: [number, number], options?: Partial<GameOptions>) {
+        if (this.gatewayPtr) {
+            try { // create a new game instance for the players
+                return this.gatewayPtr.createInstance(ids[0], ids[1], options);
+            } catch (e) {
+                return -1;
+            }
+        }
+        return 0;
+    }
 
     async matchWaitingPlayers() {
         while (true) {
-            await new Promise(resolve => setTimeout(() => { resolve(true) }, 1000));
+            await new Promise(resolve => setTimeout(() => { resolve(true) }, 2000));
 
             let i = 1;
             while (i < this.list.waiting.length) {
-    
                 // compute elo gap between the two players
                 const actualDiff = this.list.waiting[i - 1].user.elo - this.list.waiting[i].user.elo;
                 // every 15s the allowed elo gap is bigger by 250 elo
@@ -25,16 +38,25 @@ export class GameService {
     
                 // if the players have a fairly close level
                 if (actualDiff <= allowedDiff) { // it's a match !
-                    this.list.finished.push([this.list.waiting[i - 1].user, this.list.waiting[i].user])
-                    this.list.waiting.splice(i - 1, 2); // remove them from waiting list
+                    
+                    this.list.finished.push({
+                        playerOne: [this.list.waiting[i - 1].user, false],
+                        playerTwo: [this.list.waiting[i].user, false],
+                        id: 0
+                    });
+
+                    const last = this.list.finished.slice(-1)[0]; // get last match created
+                    last.id = this.createMatch([last.playerOne[0].id, last.playerTwo[0].id]);
+                    if (last.id > 0) { // if a new match has been created successfully
+                        this.list.waiting.splice(i - 1, 2); // remove the players from the waiting list
+                    }
                 }
-    
                 i++;
             }
         }
     }
 
-    matchmakingAddPlayer(player: TestUser) {
+    matchmakingAddPlayer(player: User) {
 
         let i = 0;
         while (i < this.list.waiting.length && this.list.waiting[i].user.elo > player.elo) {
@@ -46,19 +68,29 @@ export class GameService {
             user: player,
             time: Date.now()
         });
-        return this.list;
     }
 
-    matchmakingCheckMatch(playerId: number) {
-        const match = this.list.finished.find(match => {
-            return (match[0].id === playerId || match[1].id === playerId);
+    matchmakingCheckMatch(playerId: number) : number {
+        const matchIndex = this.list.finished.findIndex(match => {
+            return (match.playerOne[0].id === playerId || match.playerTwo[0].id === playerId);
         });
-
-        if (!match)
-            return null;
+        const match = this.list.finished[matchIndex];
 
         // create a new match instance
-        // return its id
+        if (this.gatewayPtr && match) {
+
+            // set the player as ready
+            match.playerOne[0].id === playerId ?
+                match.playerOne[1] = true:
+                match.playerTwo[1] = true;
+
+            if (match.playerOne[1] && match.playerTwo[1]) {
+                this.list.finished.splice(matchIndex, 1); // both players are ready, matchmaking is over
+            }
+
+            return match.id; // -1 is a fail, > 0 is a success
+        }
+        return (0);
     }
 
     async saveMatchResult(
@@ -91,7 +123,7 @@ export class GameService {
         // players[0] is the winner
         players.sort((a: User, b: User) => {
             return a.id === winner.id ? -1 : 1;
-        });
+        });body
 
         // compute new elo
         const updatedElo = this.computeNewEloScore(players[0].elo, players[1].elo);

--- a/requirements/backend/src/game/types/Matchmaking.ts
+++ b/requirements/backend/src/game/types/Matchmaking.ts
@@ -1,12 +1,14 @@
-interface TestUser {
+import { User } from "src/user/entities/user.entity";
+
+interface Match {
+	playerOne: [User, boolean],
+	playerTwo: [User, boolean],
 	id: number
-	displayName: string
-	elo: number
 }
 
 type MatchmakingList = {
-    waiting: { user: TestUser, time: number }[]
-    finished: [TestUser, TestUser][];
+    waiting: { user: User, time: number }[]
+    finished: Match[];
 }
 
-export { TestUser, MatchmakingList };
+export { MatchmakingList };

--- a/requirements/backend/src/game/types/Matchmaking.ts
+++ b/requirements/backend/src/game/types/Matchmaking.ts
@@ -1,0 +1,12 @@
+interface TestUser {
+	id: number
+	displayName: string
+	elo: number
+}
+
+type MatchmakingList = {
+    waiting: { user: TestUser, time: number }[]
+    finished: [TestUser, TestUser][];
+}
+
+export { TestUser, MatchmakingList };

--- a/requirements/backend/src/user/user.controller.ts
+++ b/requirements/backend/src/user/user.controller.ts
@@ -63,7 +63,7 @@ export class UserController {
 	@Get(':id')
 	@UseGuards(GroupGuard)
 	async getUserById(
-		@Req() req: any,
+		@Req() req: { user: User },
 		@Param('id', ParseIntPipe) id: number
 	): Promise<FindUserDTO> {
 		const userDB = await this.userService.findUserById(id);


### PR DESCRIPTION
# Nouvelles routes
## POST `/game/join`
- pas de body requis
- ajoute l'utilisateur à la liste des joueurs en attente d'un match

## POST `/game/create`
- body : `{ ids: [number, number], options: Partial<GameOptions>}`
- permet de créer un match sans passer par le matchmaking, utile pour les matchs entre amis
- renvoie l'id du match

## GET `/game/matchmaking`
- permet de savoir si un match à été trouvé pour l'utilisateur
- renvoie 0 si aucun match, -1 en cas d'erreur et l'id du match sinon

# Fonctionnement du matchmaking
Il y a une liste d'attente que les joueurs rejoignent avec la première route. Une fois dedans le serveur essaie de mettre ensemble des joueurs de niveau équivalent à chaque seconde. Il faut que la différence d'elo entre les deux joueurs soit inférieure à 250 pour qu'un match soit créé mais la recherche s'élargit de 250 elo supplémentaires pour chaque intervalle de 15 secondes dans la liste d'attente.
Une fois le match créé les deux joueurs sont déplacés dans une autre liste où ils resteront tant que la route GET n'aura pas été appelée par chacun des deux joueurs, les infos de leur match sont donc supprimées qu'une fois qu'ils ont prévenus.
Le reste est géré par le gameGateway.

PS: j'ai pas testé les matchs privés mais le reste fonctionne normalement, à voir ce que ça donne une fois couplé au front.