### PR TITLE
User info fixes

### DIFF
--- a/containers/frontend/src/components/friends/FriendRow.tsx
+++ b/containers/frontend/src/components/friends/FriendRow.tsx
@@ -95,7 +95,7 @@ const FriendRow = (props: IProps) => {
 		>
 			<div className="friend-picture">
 				<img
-					alt="friend's avatar"
+					alt="avatar"
 					src={`${process.env.REACT_APP_BACKEND_ADDRESS}/${props.data.picture}`}
 				/>
 			</div>

--- a/containers/frontend/src/components/homepage/SocialField/HSocialField.tsx
+++ b/containers/frontend/src/components/homepage/SocialField/HSocialField.tsx
@@ -70,6 +70,15 @@ const HSocialField = (props: { standalone?: boolean }) => {
 	}, [notificationHandler, chatSocket, onMessage]);
 
 	const AddFriend = async (name: string) => {
+
+		if (!name) {
+			setModalProps({
+				show: true,
+				content: <AddFriendModal cb={AddFriend} info='You must specify a username' />,
+			});
+			return ;			
+		}
+
 		try {
 			await friendList.addFriendByName(name);
 		} catch (e: any) {

--- a/containers/frontend/src/components/modals/pom-components/PomGeneralPanel.tsx
+++ b/containers/frontend/src/components/modals/pom-components/PomGeneralPanel.tsx
@@ -70,6 +70,17 @@ const PomGeneralPanel = () : JSX.Element => {
 							<input id="pom-login" type="text" placeholder={loginStatus.user?.login} disabled />
 						</div>
 						<div className="pom-gp-tc-textfield">
+							<label htmlFor="pom-email">
+								Email :
+							</label>
+							<input
+								id="pom-email"
+								type="email"
+								placeholder={loginStatus.user?.email}
+								disabled
+							/>
+						</div>
+						<div className="pom-gp-tc-textfield">
 							<label htmlFor="pom-display-name">
 								Display name :
 							</label>
@@ -79,19 +90,6 @@ const PomGeneralPanel = () : JSX.Element => {
 								placeholder={loginStatus.user?.displayName}
 								onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
 									setDisplayName(e.target.value);
-								}}
-							/>
-						</div>
-						<div className="pom-gp-tc-textfield">
-							<label htmlFor="pom-email">
-								Email :
-							</label>
-							<input
-								id="pom-email"
-								type="email"
-								placeholder={loginStatus.user?.email}
-								onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-									setEmail(e.target.value);
 								}}
 							/>
 						</div>

--- a/containers/frontend/src/components/modals/pom-components/PomGeneralPanel.tsx
+++ b/containers/frontend/src/components/modals/pom-components/PomGeneralPanel.tsx
@@ -18,6 +18,7 @@ const PomGeneralPanel = () : JSX.Element => {
 	const [ displayName, setDisplayName ] = useState<string>('');
 	const [ email, setEmail ] = useState<string>('');
 	const [ saveState, setSaveState ] = useState<number>(0);
+	const [ error, setError ] = useState<string>();
 
 	return (
 		<form className="pom-general-panel">
@@ -95,6 +96,11 @@ const PomGeneralPanel = () : JSX.Element => {
 						</div>
 					</div>
 				</div>
+			{
+				error ?
+					<p className='pom-gp-error'>Error: {error}</p> :
+					null
+			}
 			<input
 				className="pom-gp-save"
 				type="submit"
@@ -111,7 +117,10 @@ const PomGeneralPanel = () : JSX.Element => {
 								form.append('username', displayName);
 							if (uploadedAvatar)
 								form.append('picture', uploadedAvatar as File);
-							await RequestWrapper.post('/user/edit', form);
+							setError(''); // clear last error
+							await RequestWrapper.post('/user/edit', form, e => {
+								setError(e.response?.data?.message || 'Unknown');
+							});
 							setSaveState(2);
 							setTimeout(() => setSaveState(0), 1000);
 						})();

--- a/containers/frontend/src/components/modals/pom-components/styles/general_panel.scss
+++ b/containers/frontend/src/components/modals/pom-components/styles/general_panel.scss
@@ -106,6 +106,13 @@ $pom-avatar-padding: 5px;
 		}
 	}
 
+	.pom-gp-error {
+		font-weight: bold;
+		text-align: center;
+		font-size: 2rem;
+		color: red;
+	}
+
 	.pom-gp-save {
 		flex: 0 0 50px;
 		border-radius: 5px;

--- a/containers/frontend/src/components/profile/Profile.tsx
+++ b/containers/frontend/src/components/profile/Profile.tsx
@@ -31,7 +31,7 @@ const Profile = () : JSX.Element => {
             );
             setProfileCompData({...profileCompData, user: fetchUserData, isLoaded: true});
         })();
-    }, []); // eslint-disable-line
+    }, [urlData.id]);
 
     if (profileCompData?.error) {
         return (


### PR DESCRIPTION
- fix du bug qui empêchait de recharger la page de profil avec un autre utilisateur
- champ email de la modale d'édition en read-only
- affichage des messages d'erreur pour la modale d'édition
- bloque la requête `addFriend` si le champ username est laissé vide

Closes #94
Closes #95 